### PR TITLE
Use POST endpoint instead of GET

### DIFF
--- a/lib/laa/cda/prosecution_case.rb
+++ b/lib/laa/cda/prosecution_case.rb
@@ -8,9 +8,9 @@ module LAA
       def self.search(**kwargs)
         JSON.parse(
           LAA::Cda.connection.request(
-            :get,
+            :post,
             'api/internal/v2/prosecution_cases',
-            params: { filter: kwargs }
+            body: { filter: kwargs }
           ).body
         )['results'].map { |result| new(**result) }
       end

--- a/spec/laa/cda/prosecution_case_spec.rb
+++ b/spec/laa/cda/prosecution_case_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe LAA::Cda::ProsecutionCase do
             headers: { 'content-type': 'application/json' }
           )
 
-        stub_request(:get, 'http://example.com/api/internal/v2/prosecution_cases')
-          .with(query: hash_including({ filter: search_params }))
+        stub_request(:post, 'http://example.com/api/internal/v2/prosecution_cases')
+          .with(body: hash_including({ filter: search_params }))
           .to_return(
             status: 200, body: response_data.to_json,
             headers: { 'content-type': 'application/json' }


### PR DESCRIPTION
With a GET request the search parameters are added as URL parameters. These get logged by the server and this has GDPR implications. By using the POST endpoing instead the parameter can be added to the message body and these can be filtered out in the logs.